### PR TITLE
Update vercel config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,8 @@
 {
+  "git": {
+    "deploymentEnabled": false
+  },
   "github": {
-    "enabled": false,
     "silent": true
   },
   "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]

--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,10 @@
   "github": {
     "silent": true
   },
-  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
 }


### PR DESCRIPTION
The [github.enabled](https://vercel.com/docs/concepts/projects/project-configuration/git-configuration#github.enabled) config property has been deprecated in favor of [git.deploymentEnabled](https://vercel.com/docs/concepts/projects/project-configuration/git-configuration#git.deploymentenabled).  This repo was just connected to the Vercel project, so this change was made on a feature branch to test what would happen when pushing changes to the non-production branch and opening a PR.