### PR TITLE
Wrap lightgallery

### DIFF
--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -1,14 +1,27 @@
+import lgThumbnail from 'lightgallery/plugins/thumbnail';
+import lgZoom from 'lightgallery/plugins/zoom';
 import LightGallery from 'lightgallery/react';
 import { LIGHTGALLERY_LICENSE } from '../constants';
+
+const LIGHTGALLERY_PLUGINS = { lgThumbnail, lgZoom };
 
 /**
  * @param {any[]} images
  * @param {import('lightgallery/react').LightGalleryProps} props
+ * @param {('lgThumbnail' | 'lgZoom')[]} plugins
  * @returns LightGallery
  */
-export const createLightGallery = (images, props) => (
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  <LightGallery licenseKey={LIGHTGALLERY_LICENSE} download={false} {...props}>
-    {images.length === 1 ? images[0] : images}
-  </LightGallery>
-);
+export const createLightGallery = (images, props = {}, plugins = []) => {
+  const realPlugins = plugins.map((p) => LIGHTGALLERY_PLUGINS[p]);
+
+  return (
+    <LightGallery
+      licenseKey={LIGHTGALLERY_LICENSE}
+      download={false}
+      plugins={realPlugins}
+      {...props} // eslint-disable-line react/jsx-props-no-spreading
+    >
+      {images.length === 1 ? images[0] : images}
+    </LightGallery>
+  );
+};

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -1,0 +1,14 @@
+import LightGallery from 'lightgallery/react';
+import { LIGHTGALLERY_LICENSE } from '../constants';
+
+/**
+ * @param {any[]} images
+ * @param {import('lightgallery/react').LightGalleryProps} props
+ * @returns LightGallery
+ */
+export const createLightGallery = (images, props) => (
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  <LightGallery licenseKey={LIGHTGALLERY_LICENSE} download={false} {...props}>
+    {images.length === 1 ? images[0] : images}
+  </LightGallery>
+);

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,4 +1,3 @@
-import lgZoom from 'lightgallery/plugins/zoom';
 import { Link } from 'react-router-dom';
 import { summary } from '../assets/generated/resume';
 import { createLightGallery } from '../components/Lightbox';
@@ -64,10 +63,8 @@ const About = () => {
                 majestic beast
               </span>,
             ],
-            {
-              plugins: [lgZoom],
-              elementClassNames: 'inline',
-            }
+            { elementClassNames: 'inline' },
+            ['lgZoom']
           )}
         </li>
       </ul>

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,9 +1,9 @@
 import lgZoom from 'lightgallery/plugins/zoom';
-import LightGallery from 'lightgallery/react';
 import { Link } from 'react-router-dom';
 import { summary } from '../assets/generated/resume';
+import { createLightGallery } from '../components/Lightbox';
 import Page from '../components/Page';
-import { LIGHTGALLERY_LICENSE, MAILTO_MESSAGE, SLOGAN } from '../constants';
+import { MAILTO_MESSAGE, SLOGAN } from '../constants';
 
 const About = () => {
   document.title = SLOGAN;
@@ -54,20 +54,21 @@ const About = () => {
         </li>
         <li>
           I am the owner of this{' '}
-          <LightGallery
-            licenseKey={LIGHTGALLERY_LICENSE}
-            plugins={[lgZoom]}
-            elementClassNames="inline"
-            download={false}
-          >
-            <span
-              className="fancytxt"
-              data-src="/images/clark/DSC_1564-6.jpg"
-              data-sub-html="Clark the Corgi"
-            >
-              majestic beast
-            </span>
-          </LightGallery>
+          {createLightGallery(
+            [
+              <span
+                className="fancytxt"
+                data-src="/images/clark/DSC_1564-6.jpg"
+                data-sub-html="Clark the Corgi"
+              >
+                majestic beast
+              </span>,
+            ],
+            {
+              plugins: [lgZoom],
+              elementClassNames: 'inline',
+            }
+          )}
         </li>
       </ul>
 

--- a/src/pages/Build.jsx
+++ b/src/pages/Build.jsx
@@ -1,4 +1,3 @@
-import lgZoom from 'lightgallery/plugins/zoom';
 import { useParams } from 'react-router-dom';
 import { builds } from '../assets/data';
 import { createLightGallery } from '../components/Lightbox';
@@ -92,9 +91,8 @@ const Build = () => {
                   />
                 </a>,
               ],
-              {
-                plugins: [lgZoom],
-              }
+              {},
+              ['lgZoom']
             )}
           </div>
         )}

--- a/src/pages/Build.jsx
+++ b/src/pages/Build.jsx
@@ -1,9 +1,9 @@
 import lgZoom from 'lightgallery/plugins/zoom';
-import LightGallery from 'lightgallery/react';
 import { useParams } from 'react-router-dom';
 import { builds } from '../assets/data';
+import { createLightGallery } from '../components/Lightbox';
 import Page from '../components/Page';
-import { LIGHTGALLERY_LICENSE, SLOGAN } from '../constants';
+import { SLOGAN } from '../constants';
 import styles from '../styles/Build.module.css';
 import NotFound from './NotFound';
 
@@ -80,21 +80,22 @@ const Build = () => {
         </div>
         {data.image && (
           <div className={styles.pic}>
-            <LightGallery
-              licenseKey={LIGHTGALLERY_LICENSE}
-              plugins={[lgZoom]}
-              download={false}
-            >
-              <a href={data.image.path}>
-                <img
-                  src={data.image.path}
-                  className={styles[data.image.orientation]}
-                  alt={data.image.title}
-                  data-sub-html={data.image.title}
-                  title="Click to enlarge"
-                />
-              </a>
-            </LightGallery>
+            {createLightGallery(
+              [
+                <a href={data.image.path}>
+                  <img
+                    src={data.image.path}
+                    className={styles[data.image.orientation]}
+                    alt={data.image.title}
+                    data-sub-html={data.image.title}
+                    title="Click to enlarge"
+                  />
+                </a>,
+              ],
+              {
+                plugins: [lgZoom],
+              }
+            )}
           </div>
         )}
       </div>

--- a/src/pages/Project.jsx
+++ b/src/pages/Project.jsx
@@ -1,6 +1,4 @@
 import { Fragment } from 'react';
-import lgThumbnail from 'lightgallery/plugins/thumbnail';
-import lgZoom from 'lightgallery/plugins/zoom';
 import { useParams } from 'react-router-dom';
 import { projects } from '../assets/data';
 import GithubIcon from '../assets/images/icons/github.svg';
@@ -167,10 +165,8 @@ const Project = () => {
                       </Fragment>
                     )),
                 ],
-                {
-                  plugins: [lgZoom, lgThumbnail],
-                  thumbnail: true,
-                }
+                { thumbnail: true },
+                ['lgThumbnail', 'lgZoom']
               )
             )}
           </div>

--- a/src/pages/Project.jsx
+++ b/src/pages/Project.jsx
@@ -1,14 +1,14 @@
 import { Fragment } from 'react';
 import lgThumbnail from 'lightgallery/plugins/thumbnail';
 import lgZoom from 'lightgallery/plugins/zoom';
-import LightGallery from 'lightgallery/react';
 import { useParams } from 'react-router-dom';
 import { projects } from '../assets/data';
 import GithubIcon from '../assets/images/icons/github.svg';
 import ExternalLinkIcon from '../assets/images/icons/link-external.svg';
 import PlayIcon from '../assets/images/icons/play.svg';
+import { createLightGallery } from '../components/Lightbox';
 import Page from '../components/Page';
-import { LIGHTGALLERY_LICENSE, SLOGAN } from '../constants';
+import { SLOGAN } from '../constants';
 import styles from '../styles/Project.module.css';
 import NotFound from './NotFound';
 
@@ -100,24 +100,25 @@ const Project = () => {
                 {data.images.slice(0, 1).map((image) => (
                   <Fragment key={image.id}>
                     <div className={styles.gifOverlay} title="Play GIF">
-                      <LightGallery
-                        licenseKey={LIGHTGALLERY_LICENSE}
-                        onBeforeOpen={restartGif}
-                        enableDrag={false}
-                        enableSwipe={false}
-                        download={false}
-                      >
-                        <a href={image.path}>
-                          <img
-                            src={image.thumbnail}
-                            className={`${styles.imagesFull} ${
-                              styles[image.orientation]
-                            }`}
-                            alt={image.title}
-                            title="Click to enlarge"
-                          />
-                        </a>
-                      </LightGallery>
+                      {createLightGallery(
+                        [
+                          <a href={image.path}>
+                            <img
+                              src={image.thumbnail}
+                              className={`${styles.imagesFull} ${
+                                styles[image.orientation]
+                              }`}
+                              alt={image.title}
+                              title="Click to enlarge"
+                            />
+                          </a>,
+                        ],
+                        {
+                          onBeforeOpen: restartGif,
+                          enableDrag: false,
+                          enableSwipe: false,
+                        }
+                      )}
                       <PlayIcon
                         name="play"
                         className="link-image xlarge play-overlay"
@@ -129,47 +130,48 @@ const Project = () => {
                 ))}
               </>
             ) : (
-              <LightGallery
-                licenseKey={LIGHTGALLERY_LICENSE}
-                plugins={[lgZoom, lgThumbnail]}
-                thumbnail
-                download={false}
-              >
-                {data.images
-                  .sort((a, b) => a.order - b.order)
-                  .map((image, index) => (
-                    <Fragment key={image.id}>
-                      {index === 0 ? (
-                        <a href={image.path}>
-                          <img
-                            src={image.path}
-                            className={`${styles.imagesFull} ${
-                              styles[image.orientation]
-                            }`}
-                            alt={image.title}
-                            title="Click to enlarge"
-                          />
-                        </a>
-                      ) : (
-                        <div
-                          className={styles.imagesSmall}
-                          data-src={image.path}
-                        >
+              createLightGallery(
+                [
+                  data.images
+                    .sort((a, b) => a.order - b.order)
+                    .map((image, index) => (
+                      <Fragment key={image.id}>
+                        {index === 0 ? (
                           <a href={image.path}>
                             <img
                               src={image.path}
-                              className={`${styles.imagesSmall} ${
+                              className={`${styles.imagesFull} ${
                                 styles[image.orientation]
                               }`}
                               alt={image.title}
                               title="Click to enlarge"
                             />
                           </a>
-                        </div>
-                      )}
-                    </Fragment>
-                  ))}
-              </LightGallery>
+                        ) : (
+                          <div
+                            className={styles.imagesSmall}
+                            data-src={image.path}
+                          >
+                            <a href={image.path}>
+                              <img
+                                src={image.path}
+                                className={`${styles.imagesSmall} ${
+                                  styles[image.orientation]
+                                }`}
+                                alt={image.title}
+                                title="Click to enlarge"
+                              />
+                            </a>
+                          </div>
+                        )}
+                      </Fragment>
+                    )),
+                ],
+                {
+                  plugins: [lgZoom, lgThumbnail],
+                  thumbnail: true,
+                }
+              )
             )}
           </div>
         )}

--- a/test/pages/About.test.jsx
+++ b/test/pages/About.test.jsx
@@ -1,10 +1,19 @@
 import { render, screen } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as resume from '../../src/assets/generated/resume';
+import * as lightbox from '../../src/components/Lightbox';
 import About from '../../src/pages/About';
 
 describe('About page', () => {
+  let lgSpy;
+
+  beforeEach(() => {
+    lgSpy = vi
+      .spyOn(lightbox, 'createLightGallery')
+      .mockImplementation(() => {});
+  });
+
   it('excludes employment info is not currently employed', () => {
     vi.spyOn(resume, 'summary', 'get').mockReturnValue({
       mostRecentJob: {
@@ -19,6 +28,8 @@ describe('About page', () => {
     );
 
     expect(screen.queryByTestId('employment')).toBeNull();
+
+    expect(lgSpy).toHaveBeenCalledTimes(1);
   });
 
   it('displays current job if currently employed', () => {
@@ -42,6 +53,8 @@ describe('About page', () => {
     expect(employment).toHaveTextContent(
       'Currently, I am employed as a Wizard at Somewhere'
     );
+
+    expect(lgSpy).toHaveBeenCalledTimes(1);
   });
 
   it('excludes language experience if missing', () => {
@@ -55,6 +68,8 @@ describe('About page', () => {
 
     expect(screen.queryByTestId('desktop-languages')).toBeNull();
     expect(screen.queryByTestId('web-languages')).toBeNull();
+
+    expect(lgSpy).toHaveBeenCalledTimes(1);
   });
 
   it('displays language experience', () => {
@@ -83,5 +98,7 @@ describe('About page', () => {
 
     expect(desktopLanguages.children.length).toBe(3);
     expect(webLanguages.children.length).toBe(2);
+
+    expect(lgSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/pages/Build.test.jsx
+++ b/test/pages/Build.test.jsx
@@ -1,7 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as data from '../../src/assets/data';
+import * as lightbox from '../../src/components/Lightbox';
 import Build from '../../src/pages/Build';
 
 vi.mock('react-router-dom', async () => ({
@@ -11,6 +12,14 @@ vi.mock('react-router-dom', async () => ({
 }));
 
 describe('Build page', () => {
+  let lgSpy;
+
+  beforeEach(() => {
+    lgSpy = vi
+      .spyOn(lightbox, 'createLightGallery')
+      .mockImplementation(() => {});
+  });
+
   it('handles no builds', async () => {
     vi.spyOn(data, 'builds', 'get').mockReturnValue([]);
 
@@ -25,6 +34,7 @@ describe('Build page', () => {
     });
 
     expect(screen.getByText('/builds/1')).toBeInTheDocument();
+    expect(lgSpy).toHaveBeenCalledTimes(0);
   });
 
   it('handles no active builds', async () => {
@@ -57,6 +67,7 @@ describe('Build page', () => {
     });
 
     expect(screen.getByText('/builds/1')).toBeInTheDocument();
+    expect(lgSpy).toHaveBeenCalledTimes(0);
   });
 
   it('displays build details without optional fields correctly', async () => {
@@ -104,7 +115,7 @@ describe('Build page', () => {
     expect(screen.queryByText('HDD')).toBeNull();
     expect(screen.queryByText('SSD')).toBeNull();
     expect(screen.getByText(gpu)).toBeInTheDocument();
-    expect(screen.queryByTitle('Click to enlarge')).toBeNull();
+    expect(lgSpy).toHaveBeenCalledTimes(0);
     expect(screen.getByText(pcCase)).toBeInTheDocument();
     expect(screen.getByText(psu)).toBeInTheDocument();
   });
@@ -154,7 +165,7 @@ describe('Build page', () => {
     expect(screen.getByText(hdd)).toBeInTheDocument();
     expect(screen.getByText(ssd)).toBeInTheDocument();
     expect(screen.getByText(gpu)).toBeInTheDocument();
-    expect(screen.queryByTitle('Click to enlarge')).toBeNull();
+    expect(lgSpy).toHaveBeenCalledTimes(0);
     expect(screen.getByText(pcCase)).toBeInTheDocument();
     expect(screen.getByText(psu)).toBeInTheDocument();
   });
@@ -205,7 +216,7 @@ describe('Build page', () => {
     expect(screen.getByText(hdd[1])).toBeInTheDocument();
     expect(screen.getByText(ssd)).toBeInTheDocument();
     expect(screen.getByText(gpu)).toBeInTheDocument();
-    expect(screen.queryByTitle('Click to enlarge')).toBeNull();
+    expect(lgSpy).toHaveBeenCalledTimes(0);
     expect(screen.getByText(pcCase)).toBeInTheDocument();
     expect(screen.getByText(psu)).toBeInTheDocument();
   });
@@ -262,14 +273,7 @@ describe('Build page', () => {
     expect(screen.getByText(hdd)).toBeInTheDocument();
     expect(screen.getByText(ssd)).toBeInTheDocument();
     expect(screen.getByText(gpu)).toBeInTheDocument();
-    expect(screen.getByTitle('Click to enlarge')).toHaveAttribute(
-      'src',
-      image.path
-    );
-    expect(screen.getByTitle('Click to enlarge').closest('a')).toHaveAttribute(
-      'href',
-      image.path
-    );
+    expect(lgSpy).toHaveBeenCalledTimes(1);
     expect(screen.getByText(pcCase)).toBeInTheDocument();
     expect(screen.getByText(psu)).toBeInTheDocument();
   });

--- a/test/pages/Project.test.jsx
+++ b/test/pages/Project.test.jsx
@@ -1,7 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { RouterProvider, createMemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as data from '../../src/assets/data';
+import * as lightbox from '../../src/components/Lightbox';
 import Project from '../../src/pages/Project';
 
 vi.mock('react-router-dom', async () => ({
@@ -11,6 +12,14 @@ vi.mock('react-router-dom', async () => ({
 }));
 
 describe('Project page', () => {
+  let lgSpy;
+
+  beforeEach(() => {
+    lgSpy = vi
+      .spyOn(lightbox, 'createLightGallery')
+      .mockImplementation(() => {});
+  });
+
   it('handles no projects', async () => {
     vi.spyOn(data, 'projects', 'get').mockReturnValue([]);
 
@@ -25,6 +34,7 @@ describe('Project page', () => {
     });
 
     expect(screen.getByText('/projects/1')).toBeInTheDocument();
+    expect(lgSpy).toHaveBeenCalledTimes(0);
   });
 
   it('handles no active projects', async () => {
@@ -55,6 +65,7 @@ describe('Project page', () => {
     });
 
     expect(screen.getByText('/projects/1')).toBeInTheDocument();
+    expect(lgSpy).toHaveBeenCalledTimes(0);
   });
 
   it('displays project details without images correctly', async () => {
@@ -105,7 +116,7 @@ describe('Project page', () => {
       'href',
       'https://hosted.code'
     );
-    expect(screen.queryByAltText('Image 1')).toBeNull();
+    expect(lgSpy).toHaveBeenCalledTimes(0);
   });
 
   it('displays project details with images correctly', async () => {
@@ -173,14 +184,7 @@ describe('Project page', () => {
       'href',
       'https://hosted.code'
     );
-    expect(screen.getAllByAltText('Image 1')[0].closest('a')).toHaveAttribute(
-      'href',
-      '/path/to/1.png'
-    );
-    expect(screen.getAllByAltText('Image 2')[0].closest('a')).toHaveAttribute(
-      'href',
-      '/path/to/2.png'
-    );
+    expect(lgSpy).toHaveBeenCalledTimes(1);
   });
 
   it('displays project details without a web URL correctly', async () => {
@@ -207,6 +211,7 @@ describe('Project page', () => {
     });
 
     expect(screen.queryByAltText('Website')).toBeNull();
+    expect(lgSpy).toHaveBeenCalledTimes(0);
   });
 
   it('displays gif thumbnail correctly', () => {
@@ -228,13 +233,6 @@ describe('Project page', () => {
 
     render(<Project />);
 
-    expect(screen.queryByAltText('Image 1')).toHaveAttribute(
-      'src',
-      '/path/to/thumbnail.png'
-    );
-    expect(screen.queryByAltText('Image 1').closest('a')).toHaveAttribute(
-      'href',
-      '/path/to/animated.gif'
-    );
+    expect(lgSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
There have been sporadic test failures similar to the following:

```
--- Unhandled Errors ---

Vitest caught 1 unhandled error during the test run.
This might cause false positive tests. Resolve unhandled errors to make sure your tests are not affected.

--- Uncaught Exception ---
ReferenceError: window is not defined
 ❯ LightGallery.enableDrag node_modules/dist/lightgallery.es5.js:2225:17
 ❯ Timeout._onTimeout node_modules/dist/lightgallery.es5.js:909:19
 ❯ listOnTimeout node:internal/timers:573:17
 ❯ processTimers node:internal/timers:514:7

This error originated in "test/pages/Build.test.jsx" test file. It doesn't mean the error was thrown inside the file itself, but while it was running.
This error was caught after test environment was torn down. Make sure to cancel any running tasks before test finishes:
- cancel timeouts using clearTimeout and clearInterval
- wait for promises to resolve using the await keyword
```

I never ran into these failures before yesterday, but after testing it appears as though something may have changed in `vitest@0.29.0` which started triggering these errors.  Regardless, wrapping LightGallery component creation in a factory function allows the majority of references to lightgallery to exists in one spot which simplifies the pages and makes testing easier.